### PR TITLE
Add coupon redemption endpoint

### DIFF
--- a/app/api/coupons/redeem/route.ts
+++ b/app/api/coupons/redeem/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from "next/server";
+import { connectToDB } from "@/app/lib/mongodb";
+import Coupon from "@/models/Coupon";
+import Event from "@/models/Event";
+import { getSession } from "@/app/lib/auth";
+
+export async function POST(request: NextRequest) {
+  try {
+    await connectToDB();
+    const session = await getSession();
+    if (!session?.user) {
+      return NextResponse.json({ message: "No autorizado" }, { status: 401 });
+    }
+
+    const { code, eventId } = await request.json();
+    if (!code) {
+      return NextResponse.json(
+        { message: "Código de cupón requerido" },
+        { status: 400 }
+      );
+    }
+
+    const coupon = await Coupon.findOne({ code });
+    if (!coupon) {
+      return NextResponse.json({ message: "Cupón no encontrado" }, { status: 404 });
+    }
+
+    if (coupon.used) {
+      return NextResponse.json({ message: "Cupón ya canjeado" }, { status: 409 });
+    }
+
+    // Optional: verify event exists
+    let event = null;
+    if (eventId) {
+      event = await Event.findById(eventId);
+      if (!event) {
+        return NextResponse.json({ message: "Evento no encontrado" }, { status: 404 });
+      }
+    }
+
+    coupon.used = true;
+    coupon.usedBy = session.user.id as any;
+    coupon.usedAt = new Date();
+    coupon.usedEvent = event?._id ?? null;
+    await coupon.save();
+
+    return NextResponse.json({ message: "Cupón canjeado", coupon });
+  } catch (error) {
+    console.error("Error POST /api/coupons/redeem:", error);
+    return NextResponse.json({ message: "Error interno" }, { status: 500 });
+  }
+}

--- a/models/Coupon.ts
+++ b/models/Coupon.ts
@@ -8,6 +8,9 @@ export interface ICoupon {
   rewardType: "drink" | "snack" | "discount" | "other";
   expiresAt: Date;
   used: boolean;
+  usedBy?: mongoose.Types.ObjectId | null;
+  usedAt?: Date | null;
+  usedEvent?: mongoose.Types.ObjectId | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -34,6 +37,9 @@ const CouponSchema = new mongoose.Schema<CouponDocument>(
     },
     expiresAt: { type: Date, required: true },
     used: { type: Boolean, default: false },
+    usedBy: { type: mongoose.Schema.Types.ObjectId, ref: "User", default: null },
+    usedAt: { type: Date, default: null },
+    usedEvent: { type: mongoose.Schema.Types.ObjectId, ref: "Event", default: null },
   },
   {
     timestamps: true,
@@ -43,6 +49,7 @@ const CouponSchema = new mongoose.Schema<CouponDocument>(
 // Índices
 CouponSchema.index({ code: 1 }, { unique: true });
 CouponSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+CouponSchema.index({ usedBy: 1 });
 
 // Método estático para código
 CouponSchema.static("generateCode", function () {


### PR DESCRIPTION
## Summary
- extend coupon schema to track redemption details
- add API route for redeeming coupons

## Testing
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6854b25b1e6c832686a9f6f0b45bafdc