### PR TITLE
Add extensive API failure tests

### DIFF
--- a/__tests__/tickets.test.ts
+++ b/__tests__/tickets.test.ts
@@ -1,6 +1,18 @@
-jest.mock('@/models/Ticket', () => jest.fn());
+jest.mock('@/models/Ticket', () => {
+  const fn: any = jest.fn();
+  fn.find = jest.fn();
+  fn.findById = jest.fn();
+  return fn;
+});
+jest.mock('@/models/Event', () => {
+  const fn: any = jest.fn();
+  fn.findOne = jest.fn();
+  return fn;
+});
 jest.mock('@/app/lib/auth', () => ({ getSession: jest.fn() }));
 jest.mock('@/app/lib/mongodb', () => ({ connectToDB: jest.fn() }));
+
+process.env.JWT_SECRET = 'testsecret';
 
 import { POST } from '@/app/api/tickets/route';
 import Ticket from '@/models/Ticket';
@@ -24,6 +36,21 @@ describe('POST /api/tickets', () => {
     expect(res.status).toBe(401);
     const data = await res.json();
     expect(data.message).toBe('No autorizado');
+  });
+
+  it.each([
+    { missing: 'eventName', body: { eventDate: '2024-01-01', price: 50, disp: 1 } },
+    { missing: 'eventDate', body: { eventName: 'Concert', price: 50, disp: 1 } },
+    { missing: 'price', body: { eventName: 'Concert', eventDate: '2024-01-01', disp: 1 } },
+  ])('returns 400 when $missing is missing', async ({ body }) => {
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+
+    const req = mockRequest(body);
+    const res = await POST(req);
+
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toBe('Datos incompletos');
   });
 
   it('creates ticket and returns 201 for valid request', async () => {
@@ -55,5 +82,120 @@ describe('POST /api/tickets', () => {
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.message).toBe('Compra registrada con éxito');
+  });
+});
+
+describe('GET /api/tickets', () => {
+  const mockRequest = {} as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+
+    const { GET } = await import('@/app/api/tickets/route');
+    const res = await GET(mockRequest);
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.message).toBe('No autorizado');
+  });
+
+  it('returns tickets with qrToken when session is valid', async () => {
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+
+    const tickets = [
+      {
+        _id: '1',
+        eventName: 'Concert',
+        eventDate: new Date('2024-01-01'),
+        price: 100,
+      },
+    ];
+
+    (Ticket as any).find.mockReturnValue({
+      lean: () => ({
+        exec: jest.fn().mockResolvedValue(tickets),
+      }),
+    });
+
+    const { GET } = await import('@/app/api/tickets/route');
+    const res = await GET(mockRequest);
+
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.tickets).toHaveLength(1);
+    expect(data.tickets[0]).toHaveProperty('qrToken');
+  });
+});
+
+describe('POST /api/checkin', () => {
+  const mockRequest = (body: any) => ({ json: jest.fn().mockResolvedValue(body) }) as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when session is missing', async () => {
+    (getSession as jest.Mock).mockResolvedValue(null);
+    const { POST: CHECKIN } = await import('@/app/api/checkin/route');
+    const res = await CHECKIN(mockRequest({ token: 'x' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when token is missing', async () => {
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+    const { POST: CHECKIN } = await import('@/app/api/checkin/route');
+    const res = await CHECKIN(mockRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toBe('Token ausente');
+  });
+
+  it('returns 400 when token is invalid', async () => {
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+    const { POST: CHECKIN } = await import('@/app/api/checkin/route');
+    const res = await CHECKIN(mockRequest({ token: 'bad' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.message).toBe('Token inválido');
+  });
+
+  it('returns 404 when ticket not found', async () => {
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+    (Ticket as any).findById.mockResolvedValue(null);
+    const token = require('jsonwebtoken').sign({ id: '1', eventName: 'Concert' }, process.env.JWT_SECRET!);
+    const { POST: CHECKIN } = await import('@/app/api/checkin/route');
+    const res = await CHECKIN(mockRequest({ token }));
+    expect(res.status).toBe(404);
+    const data = await res.json();
+    expect(data.message).toBe('Ticket no encontrado');
+  });
+
+  it('checks in ticket successfully', async () => {
+    (getSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } });
+
+    const saveTicket = jest.fn();
+    (Ticket as any).findById.mockResolvedValue({
+      isUsed: false,
+      eventName: 'Concert',
+      save: saveTicket,
+    });
+
+    const saveEvent = jest.fn();
+    (require('@/models/Event') as any).findOne.mockReturnValue({
+      exec: jest.fn().mockResolvedValue({ save: saveEvent }),
+    });
+
+    const token = require('jsonwebtoken').sign({ id: '1', eventName: 'Concert' }, process.env.JWT_SECRET!);
+    const { POST: CHECKIN } = await import('@/app/api/checkin/route');
+    const res = await CHECKIN(mockRequest({ token }));
+
+    expect(saveTicket).toHaveBeenCalled();
+    expect(saveEvent).toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.message).toBe('Check-in exitoso');
   });
 });


### PR DESCRIPTION
## Summary
- broaden tests for POST `/api/tickets` to cover missing fields
- add GET `/api/tickets` tests ensuring qrToken generation
- cover check-in API scenarios including success and error cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c6530afd483269c4c2be99e66e4c6